### PR TITLE
Use Singleton Pattern

### DIFF
--- a/cortex-snippets-client-ruby.gemspec
+++ b/cortex-snippets-client-ruby.gemspec
@@ -2,6 +2,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cortex/snippets/version'
+require 'cortex-client'
+require 'connection_pool'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cortex-snippets-client-ruby'
@@ -18,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cortex-client', '~> 0.4.3'
+  spec.add_dependency 'cortex-client', '~> 0.4.5'
   spec.add_dependency 'connection_pool', '~> 2.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -1,31 +1,31 @@
 module Cortex
   module Snippets
-    class Client
-      attr_accessor :current_webpage
-
-      def initialize(hasharg)
-        if hasharg.has_key? :access_token
-          @cortex_client = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Cortex::Client.new(access_token: hasharg[:access_token]) }
-        else
-          @cortex_client = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Cortex::Client.new(key: hasharg[:key], secret: hasharg[:secret], base_url: hasharg[:base_url]) }
-        end
-      end
-
-      def current_webpage
-        if defined?(Rails)
-          Rails.cache.fetch("webpages/#{request_url}", expires_in: 30.minutes) do
-            @cortex_client.webpages.get_feed(request_url)
+    module Client
+      class << self
+        def cortex_client
+          if ENV['CORTEX_SNIPPET_ACCESS_TOKEN'].nil? || ENV['CORTEX_SNIPPET_ACCESS_TOKEN'].empty?
+            @cortex_client ||= ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Cortex::Client.new(access_token: ENV['CORTEX_SNIPPET_ACCESS_TOKEN']) }
+          else
+            @cortex_client ||= ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Cortex::Client.new(key: ENV['CORTEX_SNIPPET_KEY'], secret: ENV['CORTEX_SNIPPET_SECRET'], base_url: ENV['CORTEX_SNIPPET_BASE_URL']) }
           end
-        else
-          raise 'Your Web framework is not supported. Supported frameworks: Rails'
         end
-      end
 
-      private
+        def current_webpage
+          if defined?(Rails)
+            Rails.cache.fetch("webpages/#{request_url}", expires_in: 30.minutes) do
+              cortex_client.webpages.get_feed(request_url)
+            end
+          else
+            raise 'Your Web framework is not supported. Supported frameworks: Rails'
+          end
+        end
 
-      def request_url
-        # TODO: Should be turbo-easy to grab request URL from Rack, but this is fine for now
-        request.original_url
+        private
+
+        def request_url
+          # TODO: Should be turbo-easy to grab request URL from Rack, but this is fine for now
+          request.original_url
+        end
       end
     end
   end

--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -10,10 +10,10 @@ module Cortex
           end
         end
 
-        def current_webpage
+        def current_webpage(request)
           if defined?(Rails)
-            Rails.cache.fetch("webpages/#{request_url}", expires_in: 30.minutes) do
-              cortex_client.webpages.get_feed(request_url)
+            Rails.cache.fetch("webpages/#{request_url(request)}", expires_in: 30.minutes) do
+              cortex_client.webpages.get_feed(request_url(request))
             end
           else
             raise 'Your Web framework is not supported. Supported frameworks: Rails'
@@ -22,8 +22,8 @@ module Cortex
 
         private
 
-        def request_url
-          # TODO: Should be turbo-easy to grab request URL from Rack, but this is fine for now
+        def request_url(request)
+          # TODO: Should be grabbing request URL in a framework-agnostic manner, but this is fine for now
           request.original_url
         end
       end

--- a/lib/cortex/snippets/view_helpers.rb
+++ b/lib/cortex/snippets/view_helpers.rb
@@ -1,40 +1,52 @@
 module Cortex
   module Snippets
     module ViewHelpers
-      def snippet(id)
-        content_tag(:snippet, Client::current_webpage[:snippets].find { |snippet| snippet.name == id }, id: id)
+      def snippet(options = {}, &block)
+        snippet = webpage[:snippets].find { |snippet| snippet.name == options[:id] }
+
+        if snippet.empty?
+          content_tag(:snippet, capture(&block), id: options[:id])
+        else
+          content_tag(:snippet, snippet, id: options[:id])
+        end
       end
 
       def seo_title
-        Client::current_webpage[:seo_title]
+        webpage[:seo_title]
       end
 
       def seo_description
-        Client::current_webpage[:seo_description]
+        webpage[:seo_description]
       end
 
       def noindex
-        Client::current_webpage[:noindex]
+        webpage[:noindex]
       end
 
       def nofollow
-        Client::current_webpage[:nofollow]
+        webpage[:nofollow]
       end
 
       def noodp
-        Client::current_webpage[:noodp]
+        webpage[:noodp]
       end
 
       def nosnippet
-        Client::current_webpage[:nosnippet]
+        webpage[:nosnippet]
       end
 
       def noarchive
-        Client::current_webpage[:noarchive]
+        webpage[:noarchive]
       end
 
       def noimageindex
-        Client::current_webpage[:noimageindex]
+        webpage[:noimageindex]
+      end
+
+      private
+
+      def webpage
+        Client::current_webpage(request)
       end
     end
   end

--- a/lib/cortex/snippets/view_helpers.rb
+++ b/lib/cortex/snippets/view_helpers.rb
@@ -2,39 +2,39 @@ module Cortex
   module Snippets
     module ViewHelpers
       def snippet(id)
-        content_tag(:snippet, current_webpage[:snippets].find { |snippet| snippet.name == id }, id: id)
+        content_tag(:snippet, Client::current_webpage[:snippets].find { |snippet| snippet.name == id }, id: id)
       end
 
       def seo_title
-        current_webpage[:seo_title]
+        Client::current_webpage[:seo_title]
       end
 
       def seo_description
-        current_webpage[:seo_description]
+        Client::current_webpage[:seo_description]
       end
 
       def noindex
-        current_webpage[:noindex]
+        Client::current_webpage[:noindex]
       end
 
       def nofollow
-        current_webpage[:nofollow]
+        Client::current_webpage[:nofollow]
       end
 
       def noodp
-        current_webpage[:noodp]
+        Client::current_webpage[:noodp]
       end
 
       def nosnippet
-        current_webpage[:nosnippet]
+        Client::current_webpage[:nosnippet]
       end
 
       def noarchive
-        current_webpage[:noarchive]
+        Client::current_webpage[:noarchive]
       end
 
       def noimageindex
-        current_webpage[:noimageindex]
+        Client::current_webpage[:noimageindex]
       end
     end
   end


### PR DESCRIPTION
`cortex-snippets-client-ruby`'s ViewHelpers encounter some issues working with instances of the client, and we shouldn't ever need to instantiate more than one client - simplify things by enforcing the singleton pattern for the client. In addition, this includes a number of refactorings and hacks to get things working. I'd like to remove the reliance on env variables from within the Gem, and also add support for other Rack-based apps.
