### PR TITLE
cortex-client Bump

### DIFF
--- a/cortex-snippets-client-ruby.gemspec
+++ b/cortex-snippets-client-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cortex-client', '~> 0.4.5'
+  spec.add_dependency 'cortex-client', '~> 0.4.6'
   spec.add_dependency 'connection_pool', '~> 2.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end


### PR DESCRIPTION
Bump cortex-client to v0.4.6, which fixes URL param in Webpages feed request
