### PR TITLE
Better Request URL Parsing

### DIFF
--- a/cortex-snippets-client-ruby.gemspec
+++ b/cortex-snippets-client-ruby.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'cortex-client', '~> 0.4.6'
   spec.add_dependency 'connection_pool', '~> 2.2.0'
+  spec.add_dependency 'addressable', '~> 2.4.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
 end

--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -1,5 +1,6 @@
 require 'cortex-client'
 require 'connection_pool'
+require 'addressable/template'
 
 module Cortex
   module Snippets
@@ -27,7 +28,9 @@ module Cortex
 
         def request_url(request)
           # TODO: Should be grabbing request URL in a framework-agnostic manner, but this is fine for now
-          request.original_url
+          uri = Addressable::URI.parse(request.original_url)
+
+          "#{uri.scheme}://#{uri.authority}#{uri.path}"
         end
       end
     end

--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Use `Addressable` to generate a standardized, sanitized `request_url`
