### PR TITLE
Update for SEO Keywords to handle an Array

### DIFF
--- a/lib/cortex/snippets/client/helper.rb
+++ b/lib/cortex/snippets/client/helper.rb
@@ -22,7 +22,7 @@ module Cortex
         end
 
         def seo_keywords
-          webpage[:seo_keyword_list].join(" ")
+          webpage[:seo_keyword_list]
         end
 
         def noindex

--- a/lib/cortex/snippets/client/helper.rb
+++ b/lib/cortex/snippets/client/helper.rb
@@ -22,7 +22,7 @@ module Cortex
         end
 
         def seo_keywords
-          webpage[:seo_keywords]
+          webpage[:seo_keyword_list].join(" ")
         end
 
         def noindex


### PR DESCRIPTION
@toastercup @kurtedelbrock 
Changes the library to expect the seo_keyword_list array rather than the seo_keywords string, then does a simple join so all client apps get exactly what they used to expect.
