### PR TITLE
Include Explicit TagHelper Helper

### DIFF
--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -4,7 +4,7 @@ require 'addressable/uri'
 module Cortex
   module Snippets
     class Client
-      include ActionView::Helpers::TranslationHelper
+      include ActionView::Helpers::TagHelper
 
       def initialize(cortex_client)
         @cortex_client = cortex_client

--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.0.1'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
* Include `TagHelper` instead of `TranslationHelper` to get `content_tag` dependency
* Bump to `v1.0.3`