### PR TITLE
EM-1012: Removable Snippet Regions

### DIFF
--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -14,7 +14,7 @@ module Cortex
         snippets = current_webpage(request).snippets || []
         snippet = snippets.find { |snippet| snippet[:document][:name] == options[:id] }
 
-        if snippet.nil? || snippet[:document][:body].nil? || snippet[:document][:body].empty?
+        if snippet.nil? || snippet[:document][:body].nil?
           content_tag(:snippet, block, options)
         else
           content_tag(:snippet, snippet[:document][:body].html_safe, options)


### PR DESCRIPTION
This PR allows for removable snippet regions. Previously, we would pipe in the contents of the `snippet` HTML if the `body` was `empty?`. This meant that if the contents were an empty string, the region would re-appear: not exactly ideal if a PO is trying to remove an entire section. Evidently, it's been this way since the dawn of time for this library. This PR removes the `empty?` check but keeps the `nil?` checks - which are entirely sensible.