### PR TITLE
CE-204: Create Gallery widget_data_for Method

### DIFF
--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.1.5'
+    VERSION = '1.1.6'
   end
 end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -75,6 +75,10 @@ module Cortex
         carousels_widget_data&.[](section_name)
       end
 
+      def galleries_widget_data
+        JSON.parse(@webpage[:galleries_widget_json] || 'null', quirks_mode: true)
+      end
+
       def galleries_widget_data_for(section_name)
         galleries_widget_data&.[](section_name)
       end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -75,6 +75,10 @@ module Cortex
         carousels_widget_data&.[](section_name)
       end
 
+      def galleries_widget_data_for(section_name)
+        galleries_widget_data&.[](section_name)
+      end
+
       def accordion_group_widget_data
         JSON.parse(@webpage[:accordion_group_widget_json] || 'null', quirks_mode: true)
       end


### PR DESCRIPTION
This is adding in the `widget_data_for` method so I can consume galleries widget data. This should help set up the PRs for Cortex, Employer, and ESB.

https://careerbuilder.atlassian.net/browse/CE-204

Relevant PRs:
* https://github.com/cbdr/employer/pull/1013
* https://github.com/cbdr/cortex/pull/532