### PR TITLE
CE-560: Add Caching

### DIFF
--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -25,7 +25,7 @@ module Cortex
         if defined?(Rails)
           url = sanitized_webpage_url(request.original_url)
           Rails.cache.fetch("webpages/#{@cortex_client.access_token.client.id}/#{url}", race_condition_ttl: 10) do
-            Cortex::Snippets::Webpage.new(@cortex_client, url)
+            Cortex::Snippets::Webpage.new(@cortex_client, url, request.path)
           end
         else
           raise 'Your Web framework is not supported. Supported frameworks: Rails'

--- a/lib/cortex/snippets/client.rb
+++ b/lib/cortex/snippets/client.rb
@@ -25,7 +25,7 @@ module Cortex
         if defined?(Rails)
           url = sanitized_webpage_url(request.original_url)
           Rails.cache.fetch("webpages/#{@cortex_client.access_token.client.id}/#{url}", race_condition_ttl: 10) do
-            Cortex::Snippets::Webpage.new(@cortex_client, url, request.path)
+            Cortex::Snippets::Webpage.new(@cortex_client, url)
           end
         else
           raise 'Your Web framework is not supported. Supported frameworks: Rails'

--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.1.7'
+    VERSION = '1.1.8'
   end
 end

--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.1.6'
+    VERSION = '1.1.7'
   end
 end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -7,6 +7,10 @@ module Cortex
         @page_cache_key = @webpage.status == 200 ? "root#{path}@#{@contents.updated_at}" : "root#{path}"
       end
 
+      def response
+        @webpage
+      end
+
       def page_cache_key
         @page_cache_key
       end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -1,14 +1,18 @@
 module Cortex
   module Snippets
     class Webpage
-      def initialize(cortex_client, url, path)
+      def initialize(cortex_client, url)
         @webpage = cortex_client.webpages.get_feed(url)
         @contents = @webpage.contents
-        @page_cache_key = @webpage.status == 200 ? "root#{path}@#{@contents.updated_at}" : "root#{path}"
+        @page_cache_key = @webpage.status == 200 ? "view:#{url}@#{@contents.updated_at}" : "view:#{url}"
       end
 
       def response
         @webpage
+      end
+
+      def status
+        @webpage.status
       end
 
       def page_cache_key

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -1,20 +1,26 @@
 module Cortex
   module Snippets
     class Webpage
-      def initialize(cortex_client, url)
-        @webpage = cortex_client.webpages.get_feed(url).contents
+      def initialize(cortex_client, url, path)
+        @webpage = cortex_client.webpages.get_feed(url)
+        @contents = @webpage.contents
+        @page_cache_key = @webpage.status == 200 ? "root#{path}@#{@contents.updated_at}" : "root#{path}"
+      end
+
+      def page_cache_key
+        @page_cache_key
       end
 
       def seo_title
-        @webpage[:seo_title]
+        @contents[:seo_title]
       end
 
       def seo_description
-        @webpage[:seo_description]
+        @contents[:seo_description]
       end
 
       def seo_keywords
-        @webpage[:seo_keyword_list]
+        @contents[:seo_keyword_list]
       end
 
       def seo_robots
@@ -22,45 +28,45 @@ module Cortex
         index_options = [:noindex, :nofollow, :noodp, :nosnippet, :noarchive, :noimageindex]
 
         index_options.each do |index_option|
-          robot_information << index_option if @webpage[index_option]
+          robot_information << index_option if @contents[index_option]
         end
 
         robot_information
       end
 
       def noindex
-        @webpage[:noindex]
+        @contents[:noindex]
       end
 
       def nofollow
-        @webpage[:nofollow]
+        @contents[:nofollow]
       end
 
       def noodp
-        @webpage[:noodp]
+        @contents[:noodp]
       end
 
       def nosnippet
-        @webpage[:nosnippet]
+        @contents[:nosnippet]
       end
 
       def noarchive
-        @webpage[:noarchive]
+        @contents[:noarchive]
       end
 
       def noimageindex
-        @webpage[:noimageindex]
+        @contents[:noimageindex]
       end
 
       def dynamic_yield
         {
-          sku: @webpage[:dynamic_yield_sku],
-          category: @webpage[:dynamic_yield_category]
+          sku: @contents[:dynamic_yield_sku],
+          category: @contents[:dynamic_yield_category]
         }
       end
 
       def tables_widget_data
-        JSON.parse(@webpage[:tables_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:tables_widget_json] || 'null', quirks_mode: true)
       end
 
       def tables_widget_data_for(section_name)
@@ -68,7 +74,7 @@ module Cortex
       end
 
       def carousels_widget_data
-        JSON.parse(@webpage[:carousels_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:carousels_widget_json] || 'null', quirks_mode: true)
       end
 
       def carousels_widget_data_for(section_name)
@@ -76,7 +82,7 @@ module Cortex
       end
 
       def galleries_widget_data
-        JSON.parse(@webpage[:galleries_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:galleries_widget_json] || 'null', quirks_mode: true)
       end
 
       def galleries_widget_data_for(section_name)
@@ -84,7 +90,7 @@ module Cortex
       end
 
       def accordion_group_widget_data
-        JSON.parse(@webpage[:accordion_group_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:accordion_group_widget_json] || 'null', quirks_mode: true)
       end
 
       def accordion_group_widget_data_for(section_name)
@@ -92,11 +98,11 @@ module Cortex
       end
 
       def charts_widget_data
-        JSON.parse(@webpage[:charts_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:charts_widget_json] || 'null', quirks_mode: true)
       end
 
       def buy_box_widget_data
-        JSON.parse(@webpage[:buy_box_widget_json] || 'null', quirks_mode: true)
+        JSON.parse(@contents[:buy_box_widget_json] || 'null', quirks_mode: true)
       end
 
       def charts_widget_data_for(section_name)
@@ -104,7 +110,7 @@ module Cortex
       end
 
       def snippets
-        @webpage[:snippets]
+        @contents[:snippets]
       end
     end
   end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -3,6 +3,7 @@ module Cortex
     class Webpage
       def initialize(cortex_client, url)
         @webpage = cortex_client.webpages.get_feed(url)
+        binding.pry
         @contents = @webpage.contents
         @page_cache_key = @webpage.status == 200 ? "view:#{url}@#{@contents.updated_at}" : "view:#{url}"
       end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -1,23 +1,13 @@
 module Cortex
   module Snippets
     class Webpage
+      attr_reader :response, :url, :contents, :status
+
       def initialize(cortex_client, url)
-        @webpage = cortex_client.webpages.get_feed(url)
-        binding.pry
-        @contents = @webpage.contents
-        @page_cache_key = @webpage.status == 200 ? "view:#{url}@#{@contents.updated_at}" : "view:#{url}"
-      end
-
-      def response
-        @webpage
-      end
-
-      def status
-        @webpage.status
-      end
-
-      def page_cache_key
-        @page_cache_key
+        @url = url
+        @response = cortex_client.webpages.get_feed(url)
+        @status = @response.status
+        @contents = @response.contents
       end
 
       def seo_title


### PR DESCRIPTION
I have modified `Webpage` to have a method `page_cache_key` that generates a webpage key regardless if the `webpage` exists on Cortex or not. For `404` responses cache keys will just be the webpage URL, for `200` responses the key will be the url plus the `updated_at` value which means updates to the webpage will generate a new key and render the changes to be cached.  