### PR TITLE
CE-218: Create Slider widget_data_for Method

### DIFF
--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.2.4'
+    VERSION = '1.2.5'
   end
 end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -81,6 +81,14 @@ module Cortex
         galleries_widget_data&.[](section_name)
       end
 
+      def slider_widget_data
+        JSON.parse(@contents[:slider_widget_json] || 'null', quirks_mode: true)
+      end
+
+      def slider_widget_data_for(section_name)
+        slider_widget_data&.[](section_name)
+      end
+
       def card_group_widget_data
         JSON.parse(@contents[:card_group_widget_json] || 'null', quirks_mode: true)
       end


### PR DESCRIPTION
This is adding in the `widget_data_for` method so I can consume slider widget data. This should help set up the PRs for Cortex, Employer, and ESB.

https://careerbuilder.atlassian.net/browse/CE-218

Relevant PRs:
* https://github.com/cbdr/employer/pull/1107
* https://github.com/cbdr/cortex/pull/558