### PR TITLE
CE-448: Leaders Widget

### DIFF
--- a/lib/cortex/snippets/version.rb
+++ b/lib/cortex/snippets/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Snippets
-    VERSION = '1.2.5'
+    VERSION = '1.2.6'
   end
 end

--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -89,6 +89,14 @@ module Cortex
         slider_widget_data&.[](section_name)
       end
 
+      def leaders_widget_data
+        JSON.parse(@contents[:leaders_widget_json] || 'null', quirks_mode: true)
+      end
+
+      def leaders_widget_data_for(section_name)
+        leaders_widget_data&.[](section_name)
+      end
+
       def card_group_widget_data
         JSON.parse(@contents[:card_group_widget_json] || 'null', quirks_mode: true)
       end


### PR DESCRIPTION
What it says on the tin - creates the helper methods for the Leaders section. These methods are really silly.. they all do the same thing and could easily be turned into two or three simple generic methods. I'll tackle this in my 10% time.