### PR TITLE
CE-1379: Don't Index Non-Production Environments

### DIFF
--- a/lib/cortex/snippets/webpage.rb
+++ b/lib/cortex/snippets/webpage.rb
@@ -30,6 +30,7 @@ module Cortex
           robot_information << index_option if @contents[index_option]
         end
 
+        robot_information = index_options unless Rails.env.production? || Rails.env.failover?
         robot_information
       end
 


### PR DESCRIPTION
* Forces `noindex`/etc for non-Production environments